### PR TITLE
Deploy from github actions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,6 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      # PUBLISH
       - name: Docker meta
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1
@@ -41,3 +42,21 @@ jobs:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
+
+      # DEPLOY
+      - name: Get tag name
+        uses: olegtarasov/get-tag@v2.1
+
+      - name: Helm tool installer
+        uses: Azure/setup-helm@v1
+        with:
+          version: '3.2.4'
+          
+      - uses: azure/k8s-set-context@v1
+        with:
+          method: service-account
+          k8s-url: ${{ secrets.K8S_URL }}
+          k8s-secret: ${{ secrets.K8S_SECRET }}
+
+      - name: Deploy
+        run: helm upgrade --install nest ./deploy/nest-temperature-forwarder/ --namespace nest --set version=$GIT_TAG_NAME

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ kubectl exec -it influxdb -- bash
 
 ## Deployment
 
+Github Actions are triggered to build and deploy the app on release. Release
+Drafter is used to draft releases based on pull request titles. A service
+account is used to deploy via helm3. This must be created first.
+
 ### `nest_temperature_forwarder` Secret
 
 ```yaml
@@ -80,8 +84,19 @@ stringData:
           defaultBucket: nest_temperature_forwarder
 ```
 
-### Install helm chart (Manually)
+### Github Actions Setup
+
+To create the service account and permissions, a cluster-admin needs to apply
+the following:
 
 ```console
-helm install nest deploy/nest_temperature_forwarder/ -n nest
+kubectl apply -f deploy/serviceaccount.yaml
 ```
+
+[Secrets][github-actions-secrets] for github actions are as follows:
+
+- `DOCKER_TOKEN`: _The PAT token for ghcr.io_
+- `K8S_SECRET`: _The full yaml secret for the serviceaccount_
+- `K8S_URL` : _The url of the kubernetes api server_
+
+[github-actions-secrets]: https://github.com/Smirl/nest_temperature_forwarder/settings/secrets

--- a/deploy/serviceaccount.yaml
+++ b/deploy/serviceaccount.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nest
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: github-actions
+  namespace: nest
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: github-actions
+  namespace: nest
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - "*"
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  - podsecuritypolicys
+  verbs:
+  - "*"
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - "*"
+- apiGroups:
+  - extensions
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - persistentvolumeclaims
+  - pod
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - "*"
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  - roles
+  - rolebindings
+  verbs:
+  - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: github-actions
+  namespace: nest
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: github-actions
+subjects:
+- kind: ServiceAccount
+  name: github-actions
+  namespace: nest


### PR DESCRIPTION
closes #12 

- Update README with setup instructions
- Add deployment steps on tag
- create serviceaccount used by github actions to deploy
