### PR TITLE
Can run independently of influx, nest, and weather

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ to configure it.
 ### Flags
 
 ```
-usage: python temperature_forwarder.py [-h] [--health-check] [--health-check-path HEALTH_CHECK_PATH] [--health-check-delta HEALTH_CHECK_DELTA] [--once]
+usage: python temperature_forwarder.py [-h] [--health-check] [--health-check-path HEALTH_CHECK_PATH] [--health-check-delta HEALTH_CHECK_DELTA] [--postal-code POSTAL_CODE] [--delay-seconds DELAY_SECONDS] [--once] [--verbose]
 
 Get metrics from the nest API and put them into influxdb.
 
@@ -59,17 +59,22 @@ optional arguments:
                         Path on disk to store last successful run time (default: /tmp/healh_check.txt)
   --health-check-delta HEALTH_CHECK_DELTA
                         Number of minutes behind before failing healthcheck (default: 20)
+  --postal-code POSTAL_CODE
+                        A UK postal code to always get weather data for. Uses nest thermostat postal code by default. (default: None)
+  --delay-seconds DELAY_SECONDS
+                        Seconds between data points (default: 300)
   --once                Do not start scheduler. Get and store single data point (default: False)
+  --verbose             Enable verbose output (default: False)
 ```
 
 ### Environment variables
 
 | Name | Description | Default |
 | - | - | - |
-| `DELAY_SECONDS` | Seconds between data points | 300 |
-| `NEST_ACCESS_TOKEN` | API token for nest | |
-| `OPENWEATHERMAP_API_KEY` | API Key for https://openweathermap.org/ | |
-| `INFLUX_TOKEN` | API token for influxdb | |
+| `POSTAL_CODE` | A UK postal code to always get weather data for. Uses nest thermostat postal code by default. | "" |
+| `NEST_ACCESS_TOKEN` | API token for nest. If blank nest api not queried. | "" |
+| `OPENWEATHERMAP_API_KEY` | API Key for https://openweathermap.org/. If blank not external temperature data is logged. | "" |
+| `INFLUX_TOKEN` | API token for influxdb. If logged, output is only to stdout. | "" |
 | `INFLUX_URL` | influxdb full url | http://localhost:8086 |
 | `INFLUX_BUCKET` | influxdb bucket name | nest_temperature_forwarder |
 | `INFLUX_ORG` | influxdb organization name | nest_temperature_forwarder |

--- a/deploy/nest-temperature-forwarder/Chart.yaml
+++ b/deploy/nest-temperature-forwarder/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.1
+version: 4.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.1
+appVersion: 4.0.0
 
 
 dependencies:

--- a/deploy/nest-temperature-forwarder/templates/deployment.yaml
+++ b/deploy/nest-temperature-forwarder/templates/deployment.yaml
@@ -34,6 +34,9 @@ spec:
         args:
           - /opt/code/temperature_forwarder.py
           - --health-check-path={{ .Values.healthCheck.path }}
+          - --delay-seconds={{ .Values.args.delaySeconds }}
+          - --postal-code={{ .Values.args.postalCode }}
+          - {{ if .Values.args.verbose }}--verbose{{ end }}
         {{- if .Values.healthCheck.enabled }}
         livenessProbe:
           exec:

--- a/deploy/nest-temperature-forwarder/values.yaml
+++ b/deploy/nest-temperature-forwarder/values.yaml
@@ -7,7 +7,7 @@ global:
 
 image:
   repository: ghcr.io/smirl/nest_temperature_forwarder
-  tag: "v2.0.0"
+  tag: "v4.0.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -23,6 +23,11 @@ healthCheck:
 # - NEST_ACCESS_TOKEN
 # - OPENWEATHERMAP_API_KEY
 existingSecret: nest-temperature-forwarder
+
+args:
+  delaySeconds: 300
+  postalCode: ""
+  verbose: false
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
# Summary

## Configuration changes

- `INFLUX_TOKEN` is now optional. This will then only write to stdout
- `NEST_ACCESS_TOKEN` is now optional. This will not call nest at all.
- `OPENWEATHERMAP_API_KEY` is now optional. This will not get external weather at all
- `POSTAL_CODE` can be set to add an additional UK postcode to get weather for.
- `.Values.args.postalCode` is added to the chart
- `--delay-seconds` is an arg rather than an ENV var
- `.Values.args.delaySeconds` is added to the chart
- `--verbose` is an arg to give additional debugging logging
- `.Values.args.verbose` is added to the chart

## Data changes

- `weather` will not be logged in the same stdout line as thermostat data
- `weather` will not have `name` tag matching thermostat
- `weather` will have `postal_code` tag.
