### PR TITLE
Hotfix - old helm charts install out of date resources

### DIFF
--- a/deploy/nest-temperature-forwarder/values.yaml
+++ b/deploy/nest-temperature-forwarder/values.yaml
@@ -89,6 +89,9 @@ grafana:
       enabled	: true
       searchNamespace: nest
 
+  rbac:
+    pspEnabled: false
+
   admin:
     existingSecret: nest-temperature-forwarder
 
@@ -125,3 +128,7 @@ influxdb2:
     ## keys are `admin-password` and `admin-token`.
     ## If set, the password and token values above are ignored.
     existingSecret: nest-temperature-forwarder
+
+  # TODO: we need this but should upgrade chart first
+  pdb:
+    create: false


### PR DESCRIPTION
# Summary

Removes old PSP and PDBs

Longer term we need to upgrade the helm charts for grafana and influxdb